### PR TITLE
Implementa regex para detectar logs em outro formato

### DIFF
--- a/scielo_log_validator/validator.py
+++ b/scielo_log_validator/validator.py
@@ -213,7 +213,7 @@ def _date_is_much_greater(date_object, file_object_date, days_delta):
         return True
 
 
-def _analyse_dates(results, days_delta=2):
+def _analyse_dates(results, days_delta=5):
     file_path_date = results.get('path', {}).get('date', '')
     file_content_dates = results.get('content', {}).get('summary', {}).get('datetimes', {})
     probably_date = results.get('probably_date')

--- a/scielo_log_validator/validator.py
+++ b/scielo_log_validator/validator.py
@@ -134,12 +134,12 @@ def _get_content_summary(path, total_lines, sample_lines):
             if line_counter in eval_lines:
                 match = re.search(values.PATTERN_IP_DATETIME_OTHERS, decoded_line)
 
-                if match and len(match.groups()) == 3:
-                    ip_value = match.group(1)
+                if match and len(match.groups()) == 5:
+                    ip_value = match.group(2)
                     ip_type = _is_ip_local_or_remote(ip_value)
                     ips[ip_type] += 1
 
-                    matched_datetime = match.group(2)
+                    matched_datetime = match.group(3)
                     try:
                         year, month, day, hour = _extract_year_month_day_hour(matched_datetime)
 

--- a/scielo_log_validator/values.py
+++ b/scielo_log_validator/values.py
@@ -33,6 +33,6 @@ PATTERN_YMD = r'\d{4}\d{2}\d{2}'
 
 PATTERN_PAPERBOY = r'^\d{4}-\d{2}-\d{2}[\w|\.]*\.log\.gz$'
 
-PATTERN_IP_DATETIME_OTHERS = r'^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(.*)\] \"(.*)\"$'
+PATTERN_IP_DATETIME_OTHERS = r'^([\w|\W]* |)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(.*)\] (\".*\")(.*)$'
 
 PATTERN_IP_DATETIME_RESOURCE_STATUS_LENGHT_REFERRER_EQUIPMENT = r'^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(.*)\] \"GET (.*) .*\" (\d{3}) (\d*) \"(.*)\" \"(.*)\"$'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ tests_require = [
 
 setuptools.setup(
     name="scielo-log-validator",
-    version="0.2.6",
+    version="0.3.0",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",
     description="",


### PR DESCRIPTION
Arquivos de log da coleção Espanha contêm um formato ligeiramente diferente daqueles que a app atualmente suporta. Este PR torna o regex mais flexíviel, de modo que detecta os componentes de cada linha de log desse formato, mantendo compatibilidade com o que já existe.